### PR TITLE
Allow token use only

### DIFF
--- a/seafileapi/__init__.py
+++ b/seafileapi/__init__.py
@@ -1,6 +1,6 @@
 from seafileapi.client import SeafileApiClient
 
 
-def connect(server, username, password, token=None, verify_ssl=True):
+def connect(server, username=None, password=None, token=None, verify_ssl=True):
     client = SeafileApiClient(server, username, password, token, verify_ssl)
     return client


### PR DESCRIPTION
This init function prevent the usage of token only if username/password isn't define, I suggest to make also make these arguments optional.